### PR TITLE
Convert to Babel plugin and add TypeScript types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 16
           - 14
           - 12
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,19 @@
 import {PluginObj, types} from '@babel/core';
 
-export default function stripDebugPlugin(babel: {types: types}): PluginObj;
+/**
+Strip `console`, `alert`, and `debugger` statements from JavaScript code.
+
+@param babel - Babel instance, passed automatically when using Babel.
+
+@example
+```
+import {transformSync} from '@babel/core';
+import stripDebug from 'strip-debug';
+
+transformSync('function foo(){console.log("foo");alert("foo");debugger;}', {
+  plugins: [stripDebug]
+}).code;
+//=> 'function foo() { void 0;void 0; }'
+```
+*/
+export default function stripDebugPlugin(babel: {readonly types: typeof types}): PluginObj;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import {PluginObj, types} from '@babel/core';
 /**
 Strip `console`, `alert`, and `debugger` statements from JavaScript code.
 
-@param babel - Babel instance, passed automatically when using Babel.
+@param babel - Babel instance. Passed automatically when using Babel.
 
 @example
 ```
@@ -11,7 +11,7 @@ import {transformSync} from '@babel/core';
 import stripDebug from 'strip-debug';
 
 transformSync('function foo(){console.log("foo");alert("foo");debugger;}', {
-  plugins: [stripDebug]
+	plugins: [stripDebug]
 }).code;
 //=> 'function foo() { void 0;void 0; }'
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+import {PluginObj, types} from '@babel/core';
+
+export default function stripDebugPlugin(babel: {types: types}): PluginObj;

--- a/index.js
+++ b/index.js
@@ -5,23 +5,23 @@ const stripFunctionNameList = [
 	'window.console.log'
 ];
 
-export default function stripDebugPlugin({types: t}) {
+export default function stripDebugPlugin({types}) {
 	return {
 		visitor: {
 			DebuggerStatement(path) {
 				path.remove();
 			},
 			CallExpression(path) {
-				const isMatched = stripFunctionNameList.some(fnName => {
+				const isMatched = stripFunctionNameList.some(functionName => {
 					const calleePath = path.get('callee');
-					if (calleePath.matchesPattern(fnName)) {
+					if (calleePath.matchesPattern(functionName)) {
 						return !calleePath.node.computed;
 					}
 
-					return calleePath.node.name === fnName;
+					return calleePath.node.name === functionName;
 				});
 				if (isMatched) {
-					path.replaceWith(t.unaryExpression('void', t.numericLiteral(0)));
+					path.replaceWith(types.unaryExpression('void', types.numericLiteral(0)));
 				}
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -1,26 +1,29 @@
-'use strict';
-const rocambole = require('rocambole');
-const stripDebugger = require('rocambole-strip-debugger');
-const stripConsole = require('rocambole-strip-console');
-const stripAlert = require('rocambole-strip-alert');
-const espree = require('espree');
+const stripFunctionNameList = [
+	'alert',
+	'window.alert',
+	'console.log',
+	'window.console.log'
+];
 
-rocambole.parseFn = espree.parse;
-rocambole.parseContext = espree;
-rocambole.parseOptions = {
-	range: true,
-	tokens: true,
-	comment: true,
-	ecmaVersion: 2019,
-	ecmaFeatures: {
-		jsx: true,
-		globalReturn: false,
-		impliedStrict: false
-	}
-};
+export default function stripDebugPlugin({types: t}) {
+	return {
+		visitor: {
+			DebuggerStatement(path) {
+				path.remove();
+			},
+			CallExpression(path) {
+				const isMatched = stripFunctionNameList.some(fnName => {
+					const calleePath = path.get('callee');
+					if (calleePath.matchesPattern(fnName)) {
+						return !calleePath.node.computed;
+					}
 
-module.exports = source => rocambole.moonwalk(source, node => {
-	stripDebugger(node);
-	stripConsole(node);
-	stripAlert(node);
-});
+					return calleePath.node.name === fnName;
+				});
+				if (isMatched) {
+					path.replaceWith(t.unaryExpression('void', t.numericLiteral(0)));
+				}
+			}
+		}
+	};
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "strip-debug",
-	"version": "6.0.0",
+	"version": "5.0.0",
 	"description": "Strip console, alert, and debugger statements from JavaScript code",
 	"license": "MIT",
 	"repository": "sindresorhus/strip-debug",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "strip-debug",
-	"version": "5.0.0",
+	"version": "6.0.0",
 	"description": "Strip console, alert, and debugger statements from JavaScript code",
 	"license": "MIT",
 	"repository": "sindresorhus/strip-debug",
@@ -10,6 +10,8 @@
 		"email": "sindresorhus@gmail.com",
 		"url": "https://sindresorhus.com"
 	},
+	"type": "module",
+	"exports": "./index.js",
 	"engines": {
 		"node": ">=12"
 	},
@@ -32,17 +34,14 @@
 		"js",
 		"javascript",
 		"ast",
-		"esprima"
+		"babel-plugin"
 	],
 	"dependencies": {
-		"espree": "^7.3.1",
-		"rocambole": "^0.7.0",
-		"rocambole-strip-alert": "^1.0.0",
-		"rocambole-strip-console": "^2.0.0",
-		"rocambole-strip-debugger": "^1.0.1"
+		"@types/babel__core": "^7.1.14"
 	},
 	"devDependencies": {
-		"ava": "^2.4.0",
+		"@babel/core": "^7.14.3",
+		"ava": "^3.15.0",
 		"xo": "^0.38.2"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ import {transformSync} from '@babel/core';
 import stripDebug from 'strip-debug';
 
 transformSync('function foo(){console.log("foo");alert("foo");debugger;}', {
-  plugins: [stripDebug]
+	plugins: [stripDebug]
 }).code;
 //=> 'function foo() { void 0;void 0; }'
 ```

--- a/readme.md
+++ b/readme.md
@@ -4,40 +4,27 @@
 
 Useful for making sure you didn't leave any logging in production code.
 
-Also available as [Gulp](https://github.com/sindresorhus/gulp-strip-debug)/[Grunt](https://github.com/sindresorhus/grunt-strip-debug)/[Broccoli](https://github.com/sindresorhus/broccoli-strip-debug) plugins.
-
 ## Usage
 
 ```
-$ npm install strip-debug
+$ npm install @babel/core strip-debug
 ```
 
 ## Usage
 
 ```js
-const stripDebug = require('strip-debug');
+import {transformSync} from '@babel/core';
+import stripDebug from 'strip-debug';
 
-stripDebug('function foo(){console.log("foo");alert("foo");debugger;}').toString();
-//=> 'function foo(){void 0;void 0;}'
+transformSync('function foo(){console.log("foo");alert("foo");debugger;}', {
+  plugins: [stripDebug]
+}).code;
+//=> 'function foo() { void 0;void 0; }'
 ```
-
-### API
-
-## stripDebug(input)
-
-Returns the modified [Esprima AST](http://esprima.org) which can be used to make additional modifications.
-
-Call `.toString()` to get the stringified output.
 
 To prevent any side-effects, `console.*`/`alert*` is replaced with `void 0` instead of being stripped.
 
 If you shadow the `console` global with your own local variable, it will still be removed.
-
-### input
-
-Type: `string` `Object`
-
-Pass in a string of JavaScript code or a [Esprima compatible AST](http://esprima.org).
 
 ## Related
 


### PR DESCRIPTION
Fixes #20

This is based on #21 but preserves existing tests and repository infrastructure.

Since this is a total rewrite, I updated the code to use ES Modules based on the changes in [is-fn](https://github.com/sindresorhus/is-fn/commit/c5de8e5578cc12a983e8dbdd56104fa9aa6e07ed).