### PR TITLE
Support globalThis and all console methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,50 @@
-const stripFunctionNameList = [
-	'alert',
-	'window.alert',
-	'console.log',
-	'window.console.log'
-];
+const globals = new Set(['window', 'globalThis']);
 
+/**
+Collapse `window` and `globalThis`.
+
+@param {import('@babel/core').NodePath} main - Node that may be on a global object.
+
+@returns {import('@babel/core').NodePath} Collapsed node.
+*/
+function collapseGlobal(main) {
+	if (main.isMemberExpression()) {
+		const object = main.get('object');
+		if (object.isIdentifier() && globals.has(object.node.name) && main.has('property')) {
+			return main.get('property');
+		}
+	}
+
+	return main;
+}
+
+/**
+@param {import('@babel/core').NodePath<import('@babel/core').CallExpression>} path
+*/
+function isConsoleNode(path) {
+	const expression = path.get('callee');
+
+	if (!expression.isMemberExpression()) {
+		return;
+	}
+
+	const main = collapseGlobal(expression.get('object'));
+
+	return main.isIdentifier({name: 'console'}) && expression.has('property');
+}
+
+/**
+@param {import('@babel/core').NodePath<import('@babel/core').CallExpression>} path
+*/
+function isAlertNode(path) {
+	const main = collapseGlobal(path.get('callee'));
+
+	return main.isIdentifier({name: 'alert'});
+}
+
+/**
+@returns {import('@babel/core').PluginObj}
+*/
 export default function stripDebugPlugin({types}) {
 	return {
 		visitor: {
@@ -12,16 +52,7 @@ export default function stripDebugPlugin({types}) {
 				path.remove();
 			},
 			CallExpression(path) {
-				const isMatched = stripFunctionNameList.some(functionName => {
-					const calleePath = path.get('callee');
-					if (calleePath.matchesPattern(functionName)) {
-						return !calleePath.node.computed;
-					}
-
-					return calleePath.node.name === functionName;
-				});
-
-				if (isMatched) {
+				if (isConsoleNode(path) || isAlertNode(path)) {
 					path.replaceWith(types.unaryExpression('void', types.numericLiteral(0)));
 				}
 			}

--- a/test.js
+++ b/test.js
@@ -17,7 +17,9 @@ test('strip debugger statement', async t => {
 
 test('strip console statement', async t => {
 	t.is(await stripDebug('function test(){console.log("foo");}'), 'function test() {\n  void 0;\n}');
+	t.is(await stripDebug('function test(){console.warn("foo");}'), 'function test() {\n  void 0;\n}');
 	t.is(await stripDebug('function test(){window.console.log("foo");}'), 'function test() {\n  void 0;\n}');
+	t.is(await stripDebug('function test(){globalThis.console.log("foo");}'), 'function test() {\n  void 0;\n}');
 	t.is(await stripDebug('var test = () => console.log("foo");'), 'var test = () => void 0;');
 	t.is(await stripDebug('"use strict";console.log("foo");foo()'), '"use strict";\n\nvoid 0;\nfoo();');
 	t.is(await stripDebug('if(console){console.log("foo", "bar");}'), 'if (console) {\n  void 0;\n}');
@@ -29,6 +31,7 @@ test('strip console statement', async t => {
 test('strip alert statement', async t => {
 	t.is(await stripDebug('function test(){alert("foo");}'), 'function test() {\n  void 0;\n}');
 	t.is(await stripDebug('function test(){window.alert("foo");}'), 'function test() {\n  void 0;\n}');
+	t.is(await stripDebug('function test(){globalThis.alert("foo");}'), 'function test() {\n  void 0;\n}');
 	t.is(await stripDebug('var test = () => alert("foo");'), 'var test = () => void 0;');
 	t.is(await stripDebug('"use strict";alert("foo");foo()'), '"use strict";\n\nvoid 0;\nfoo();');
 	t.is(await stripDebug('if(alert){alert("foo", "bar");}'), 'if (alert) {\n  void 0;\n}');
@@ -39,7 +42,9 @@ test('strip alert statement', async t => {
 test('never strip away non-debugging code', async t => {
 	const fixture = `var test = {
   getReadSections: function () {
+    foo.console.log('started');
     var readSections = window.localStorage.getItestripDebug('storyReadSections') || '[]';
+    foo.alert('done');
     return JSON.parse(readSections);
   }
 };`;


### PR DESCRIPTION
Follow up on #24 to fix `console.{warn,info,etc}` support. Also adds support for `globalThis`.

I changed algorithm from what was written in #21 to something based on rocambole-strip-console and rocambole-strip-alert.

Also added test for the new features.